### PR TITLE
Add perspective_transform for ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/image/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/image/__init__.py
@@ -10,6 +10,7 @@ from keras.src.ops.image import extract_patches
 from keras.src.ops.image import hsv_to_rgb
 from keras.src.ops.image import map_coordinates
 from keras.src.ops.image import pad_images
+from keras.src.ops.image import perspective_transform
 from keras.src.ops.image import resize
 from keras.src.ops.image import rgb_to_grayscale
 from keras.src.ops.image import rgb_to_hsv

--- a/keras/api/ops/image/__init__.py
+++ b/keras/api/ops/image/__init__.py
@@ -10,6 +10,7 @@ from keras.src.ops.image import extract_patches
 from keras.src.ops.image import hsv_to_rgb
 from keras.src.ops.image import map_coordinates
 from keras.src.ops.image import pad_images
+from keras.src.ops.image import perspective_transform
 from keras.src.ops.image import resize
 from keras.src.ops.image import rgb_to_grayscale
 from keras.src.ops.image import rgb_to_hsv

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -493,6 +493,257 @@ def affine_transform(
     return affined
 
 
+def perspective_transform(
+    images,
+    start_points,
+    end_points,
+    interpolation="bilinear",
+    fill_value=0,
+    data_format=None,
+):
+    data_format = backend.standardize_data_format(data_format)
+    start_points = convert_to_tensor(start_points)
+    end_points = convert_to_tensor(end_points)
+
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS:
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{AFFINE_TRANSFORM_INTERPOLATIONS}. Received: "
+            f"interpolation={interpolation}"
+        )
+
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    if start_points.ndim not in (2, 3) or start_points.shape[-2:] != (4, 2):
+        raise ValueError(
+            "Invalid start_points shape: expected (4,2) for a single image"
+            f" or (N,4,2) for a batch. Received shape: {start_points.shape}"
+        )
+    if end_points.ndim not in (2, 3) or end_points.shape[-2:] != (4, 2):
+        raise ValueError(
+            "Invalid end_points shape: expected (4,2) for a single image"
+            f" or (N,4,2) for a batch. Received shape: {end_points.shape}"
+        )
+    if start_points.shape != end_points.shape:
+        raise ValueError(
+            "start_points and end_points must have the same shape."
+            f" Received start_points.shape={start_points.shape}, "
+            f"end_points.shape={end_points.shape}"
+        )
+
+    input_dtype = images.dtype
+    if input_dtype == "float16":
+        images = images.astype("float32")
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = np.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if len(start_points.shape) == 2:
+        start_points = np.expand_dims(start_points, axis=0)
+    if len(end_points.shape) == 2:
+        end_points = np.expand_dims(end_points, axis=0)
+
+    if data_format == "channels_first":
+        images = np.transpose(images, (0, 2, 3, 1))
+
+    batch_size, height, width, channels = images.shape
+
+    transforms = compute_homography_matrix(start_points, end_points)
+
+    if len(transforms.shape) == 1:
+        transforms = np.expand_dims(transforms, axis=0)
+    if transforms.shape[0] == 1 and batch_size > 1:
+        transforms = np.tile(transforms, (batch_size, 1))
+
+    x, y = np.meshgrid(
+        np.arange(width, dtype=np.float32),
+        np.arange(height, dtype=np.float32),
+        indexing="xy",
+    )
+
+    output = np.empty((batch_size, height, width, channels))
+
+    for i in range(batch_size):
+        a0, a1, a2, a3, a4, a5, a6, a7 = transforms[i]
+        denom = a6 * x + a7 * y + 1.0
+        x_in = (a0 * x + a1 * y + a2) / denom
+        y_in = (a3 * x + a4 * y + a5) / denom
+
+        coords = np.stack([y_in.ravel(), x_in.ravel()], axis=0)
+
+        mapped_channels = []
+        for channel in range(channels):
+            channel_img = images[i, :, :, channel]
+
+            mapped_channel = map_coordinates(
+                channel_img,
+                coords,
+                order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                fill_mode="constant",
+                fill_value=fill_value,
+            )
+            mapped_channels.append(mapped_channel.reshape(height, width))
+
+        output[i] = np.stack(mapped_channels, axis=-1)
+
+    if data_format == "channels_first":
+        output = np.transpose(output, (0, 3, 1, 2))
+    if need_squeeze:
+        output = np.squeeze(output, axis=0)
+    output = output.astype(input_dtype)
+
+    return output
+
+
+def compute_homography_matrix(start_points, end_points):
+    start_x1, start_y1 = start_points[:, 0, 0], start_points[:, 0, 1]
+    start_x2, start_y2 = start_points[:, 1, 0], start_points[:, 1, 1]
+    start_x3, start_y3 = start_points[:, 2, 0], start_points[:, 2, 1]
+    start_x4, start_y4 = start_points[:, 3, 0], start_points[:, 3, 1]
+
+    end_x1, end_y1 = end_points[:, 0, 0], end_points[:, 0, 1]
+    end_x2, end_y2 = end_points[:, 1, 0], end_points[:, 1, 1]
+    end_x3, end_y3 = end_points[:, 2, 0], end_points[:, 2, 1]
+    end_x4, end_y4 = end_points[:, 3, 0], end_points[:, 3, 1]
+
+    coefficient_matrix = np.stack(
+        [
+            np.stack(
+                [
+                    end_x1,
+                    end_y1,
+                    np.ones_like(end_x1),
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    -start_x1 * end_x1,
+                    -start_x1 * end_y1,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    end_x1,
+                    end_y1,
+                    np.ones_like(end_x1),
+                    -start_y1 * end_x1,
+                    -start_y1 * end_y1,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    end_x2,
+                    end_y2,
+                    np.ones_like(end_x2),
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    -start_x2 * end_x2,
+                    -start_x2 * end_y2,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    end_x2,
+                    end_y2,
+                    np.ones_like(end_x2),
+                    -start_y2 * end_x2,
+                    -start_y2 * end_y2,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    end_x3,
+                    end_y3,
+                    np.ones_like(end_x3),
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    -start_x3 * end_x3,
+                    -start_x3 * end_y3,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    end_x3,
+                    end_y3,
+                    np.ones_like(end_x3),
+                    -start_y3 * end_x3,
+                    -start_y3 * end_y3,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    end_x4,
+                    end_y4,
+                    np.ones_like(end_x4),
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    -start_x4 * end_x4,
+                    -start_x4 * end_y4,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    end_x4,
+                    end_y4,
+                    np.ones_like(end_x4),
+                    -start_y4 * end_x4,
+                    -start_y4 * end_y4,
+                ],
+                axis=-1,
+            ),
+        ],
+        axis=1,
+    )
+
+    target_vector = np.stack(
+        [
+            start_x1,
+            start_y1,
+            start_x2,
+            start_y2,
+            start_x3,
+            start_y3,
+            start_x4,
+            start_y4,
+        ],
+        axis=-1,
+    )
+    target_vector = np.expand_dims(target_vector, axis=-1)
+
+    homography_matrix = np.linalg.solve(coefficient_matrix, target_vector)
+    homography_matrix = np.reshape(homography_matrix, [-1, 8])
+
+    return homography_matrix
+
+
 MAP_COORDINATES_FILL_MODES = {
     "constant",
     "nearest",

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -444,6 +444,255 @@ def affine_transform(
     return affined
 
 
+def perspective_transform(
+    images,
+    start_points,
+    end_points,
+    interpolation="bilinear",
+    fill_value=0,
+    data_format=None,
+):
+    data_format = backend.standardize_data_format(data_format)
+
+    images = convert_to_tensor(images)
+    start_points = torch.tensor(start_points, dtype=torch.float32)
+    end_points = torch.tensor(end_points, dtype=torch.float32)
+
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+
+    if images.ndim not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    if start_points.shape[-2:] != (4, 2) or start_points.dim() not in (2, 3):
+        raise ValueError(
+            "Invalid start_points shape: expected (4,2) for a single image"
+            f" or (N,4,2) for a batch. Received shape: {start_points.shape}"
+        )
+    if end_points.shape[-2:] != (4, 2) or end_points.dim() not in (2, 3):
+        raise ValueError(
+            "Invalid end_points shape: expected (4,2) for a single image"
+            f" or (N,4,2) for a batch. Received shape: {end_points.shape}"
+        )
+    if start_points.shape != end_points.shape:
+        raise ValueError(
+            "start_points and end_points must have the same shape."
+            f" Received start_points.shape={start_points.shape}, "
+            f"end_points.shape={end_points.shape}"
+        )
+
+    need_squeeze = False
+    if images.ndim == 3:
+        images = images.unsqueeze(dim=0)
+        need_squeeze = True
+
+    if start_points.ndim == 2:
+        start_points = start_points.unsqueeze(dim=0)
+    if end_points.ndim == 2:
+        end_points = end_points.unsqueeze(dim=0)
+
+    if data_format == "channels_first":
+        images = images.permute((0, 2, 3, 1))
+
+    batch_size, height, width, channels = images.shape
+
+    transforms = compute_homography_matrix(start_points, end_points)
+
+    if transforms.dim() == 1:
+        transforms = transforms.unsqueeze(0)
+    if transforms.shape[0] == 1 and batch_size > 1:
+        transforms = transforms.repeat(batch_size, 1)
+
+    grid_x, grid_y = torch.meshgrid(
+        torch.arange(width, dtype=torch.float32, device=images.device),
+        torch.arange(height, dtype=torch.float32, device=images.device),
+        indexing="xy",
+    )
+
+    output = torch.empty(
+        [batch_size, height, width, channels], device=images.device
+    )
+
+    for i in range(batch_size):
+        a0, a1, a2, a3, a4, a5, a6, a7 = transforms[i]
+        denom = a6 * grid_x + a7 * grid_y + 1.0
+        x_in = (a0 * grid_x + a1 * grid_y + a2) / denom
+        y_in = (a3 * grid_x + a4 * grid_y + a5) / denom
+
+        coords = torch.stack([y_in.flatten(), x_in.flatten()], dim=0)
+        mapped_channels = []
+        for channel in range(channels):
+            channel_img = images[i, :, :, channel]
+            mapped_channel = map_coordinates(
+                channel_img,
+                coords,
+                order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                fill_mode="constant",
+                fill_value=fill_value,
+            )
+            mapped_channels.append(mapped_channel.reshape(height, width))
+        output[i] = torch.stack(mapped_channels, dim=-1)
+
+    if data_format == "channels_first":
+        output = output.permute((0, 3, 1, 2))
+    if need_squeeze:
+        output = output.squeeze(dim=0)
+
+    return output
+
+
+def compute_homography_matrix(start_points, end_points):
+    start_points = convert_to_tensor(start_points, dtype=torch.float32)
+    end_points = convert_to_tensor(end_points, dtype=torch.float32)
+
+    start_x1, start_y1 = start_points[:, 0, 0], start_points[:, 0, 1]
+    start_x2, start_y2 = start_points[:, 1, 0], start_points[:, 1, 1]
+    start_x3, start_y3 = start_points[:, 2, 0], start_points[:, 2, 1]
+    start_x4, start_y4 = start_points[:, 3, 0], start_points[:, 3, 1]
+
+    end_x1, end_y1 = end_points[:, 0, 0], end_points[:, 0, 1]
+    end_x2, end_y2 = end_points[:, 1, 0], end_points[:, 1, 1]
+    end_x3, end_y3 = end_points[:, 2, 0], end_points[:, 2, 1]
+    end_x4, end_y4 = end_points[:, 3, 0], end_points[:, 3, 1]
+
+    coefficient_matrix = torch.stack(
+        [
+            torch.stack(
+                [
+                    end_x1,
+                    end_y1,
+                    torch.ones_like(end_x1),
+                    torch.zeros_like(end_x1),
+                    torch.zeros_like(end_x1),
+                    torch.zeros_like(end_x1),
+                    -start_x1 * end_x1,
+                    -start_x1 * end_y1,
+                ],
+                dim=-1,
+            ),
+            torch.stack(
+                [
+                    torch.zeros_like(end_x1),
+                    torch.zeros_like(end_x1),
+                    torch.zeros_like(end_x1),
+                    end_x1,
+                    end_y1,
+                    torch.ones_like(end_x1),
+                    -start_y1 * end_x1,
+                    -start_y1 * end_y1,
+                ],
+                dim=-1,
+            ),
+            torch.stack(
+                [
+                    end_x2,
+                    end_y2,
+                    torch.ones_like(end_x2),
+                    torch.zeros_like(end_x2),
+                    torch.zeros_like(end_x2),
+                    torch.zeros_like(end_x2),
+                    -start_x2 * end_x2,
+                    -start_x2 * end_y2,
+                ],
+                dim=-1,
+            ),
+            torch.stack(
+                [
+                    torch.zeros_like(end_x2),
+                    torch.zeros_like(end_x2),
+                    torch.zeros_like(end_x2),
+                    end_x2,
+                    end_y2,
+                    torch.ones_like(end_x2),
+                    -start_y2 * end_x2,
+                    -start_y2 * end_y2,
+                ],
+                dim=-1,
+            ),
+            torch.stack(
+                [
+                    end_x3,
+                    end_y3,
+                    torch.ones_like(end_x3),
+                    torch.zeros_like(end_x3),
+                    torch.zeros_like(end_x3),
+                    torch.zeros_like(end_x3),
+                    -start_x3 * end_x3,
+                    -start_x3 * end_y3,
+                ],
+                dim=-1,
+            ),
+            torch.stack(
+                [
+                    torch.zeros_like(end_x3),
+                    torch.zeros_like(end_x3),
+                    torch.zeros_like(end_x3),
+                    end_x3,
+                    end_y3,
+                    torch.ones_like(end_x3),
+                    -start_y3 * end_x3,
+                    -start_y3 * end_y3,
+                ],
+                dim=-1,
+            ),
+            torch.stack(
+                [
+                    end_x4,
+                    end_y4,
+                    torch.ones_like(end_x4),
+                    torch.zeros_like(end_x4),
+                    torch.zeros_like(end_x4),
+                    torch.zeros_like(end_x4),
+                    -start_x4 * end_x4,
+                    -start_x4 * end_y4,
+                ],
+                dim=-1,
+            ),
+            torch.stack(
+                [
+                    torch.zeros_like(end_x4),
+                    torch.zeros_like(end_x4),
+                    torch.zeros_like(end_x4),
+                    end_x4,
+                    end_y4,
+                    torch.ones_like(end_x4),
+                    -start_y4 * end_x4,
+                    -start_y4 * end_y4,
+                ],
+                dim=-1,
+            ),
+        ],
+        dim=1,
+    )
+
+    target_vector = torch.stack(
+        [
+            start_x1,
+            start_y1,
+            start_x2,
+            start_y2,
+            start_x3,
+            start_y3,
+            start_x4,
+            start_y4,
+        ],
+        dim=-1,
+    ).unsqueeze(-1)
+
+    homography_matrix = torch.linalg.solve(coefficient_matrix, target_vector)
+    homography_matrix = homography_matrix.reshape(-1, 8)
+
+    return homography_matrix
+
+
 def _mirror_index_fixer(index, size):
     s = size - 1  # Half-wavelength of triangular wave
     # Scaled, integer-valued version of the triangular wave |x - round(x)|

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -163,6 +163,22 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         out = kimage.crop_images(x, 2, 3, target_height=10, target_width=20)
         self.assertEqual(out.shape, (3, 10, 20))
 
+    def test_perspective_transform(self):
+        # Test channels_last
+        x = KerasTensor([None, 20, 20, 3])
+        start_points = KerasTensor([None, 4, 2])
+        end_points = KerasTensor([None, 4, 2])
+        out = kimage.perspective_transform(x, start_points, end_points)
+        self.assertEqual(out.shape, (None, 20, 20, 3))
+
+        # Test channels_first
+        backend.set_image_data_format("channels_first")
+        x = KerasTensor([None, 3, 20, 20])
+        start_points = KerasTensor([None, 4, 2])
+        end_points = KerasTensor([None, 4, 2])
+        out = kimage.perspective_transform(x, start_points, end_points)
+        self.assertEqual(out.shape, (None, 3, 20, 20))
+
 
 class ImageOpsStaticShapeTest(testing.TestCase):
     def setUp(self):
@@ -362,6 +378,22 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         )
         self.assertEqual(out_batch.shape, (2, 3, 10, 20))
 
+    def test_perspective_transform(self):
+        # Test channels_last
+        x = KerasTensor([20, 20, 3])
+        start_points = KerasTensor([4, 2])
+        end_points = KerasTensor([4, 2])
+        out = kimage.perspective_transform(x, start_points, end_points)
+        self.assertEqual(out.shape, (20, 20, 3))
+
+        # Test channels_first
+        backend.set_image_data_format("channels_first")
+        x = KerasTensor([3, 20, 20])
+        start_points = KerasTensor([4, 2])
+        end_points = KerasTensor([4, 2])
+        out = kimage.perspective_transform(x, start_points, end_points)
+        self.assertEqual(out.shape, (3, 20, 20))
+
 
 AFFINE_TRANSFORM_INTERPOLATIONS = {  # map to order
     "nearest": 0,
@@ -439,6 +471,219 @@ def _fixed_map_coordinates(
         padded, shifted_coords, order=order, mode=fill_mode, cval=fill_value
     )
     return result
+
+
+def _perspective_transform_numpy(
+    images,
+    start_points,
+    end_points,
+    interpolation="bilinear",
+    fill_value=0,
+    data_format=None,
+):
+    data_format = backend.standardize_data_format(data_format)
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = np.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if len(start_points.shape) == 2:
+        start_points = np.expand_dims(start_points, axis=0)
+    if len(end_points.shape) == 2:
+        end_points = np.expand_dims(end_points, axis=0)
+
+    if data_format == "channels_first":
+        images = np.transpose(images, (0, 2, 3, 1))
+
+    batch_size, height, width, channels = images.shape
+
+    transforms = _compute_homography_matrix(start_points, end_points)
+
+    if len(transforms.shape) == 1:
+        transforms = np.expand_dims(transforms, axis=0)
+    if transforms.shape[0] == 1 and batch_size > 1:
+        transforms = np.tile(transforms, (batch_size, 1))
+
+    x, y = np.meshgrid(
+        np.arange(width, dtype=np.float32),
+        np.arange(height, dtype=np.float32),
+        indexing="xy",
+    )
+
+    output = np.empty((batch_size, height, width, channels))
+
+    for i in range(batch_size):
+        a0, a1, a2, a3, a4, a5, a6, a7 = transforms[i]
+        denom = a6 * x + a7 * y + 1.0
+        x_in = (a0 * x + a1 * y + a2) / denom
+        y_in = (a3 * x + a4 * y + a5) / denom
+
+        coords = np.stack([y_in.ravel(), x_in.ravel()], axis=0)
+
+        mapped_channels = []
+        for channel in range(channels):
+            channel_img = images[i, :, :, channel]
+
+            mapped_channel = _fixed_map_coordinates(
+                channel_img,
+                coords,
+                order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                fill_mode="constant",
+                fill_value=fill_value,
+            )
+            mapped_channels.append(mapped_channel.reshape(height, width))
+
+        output[i] = np.stack(mapped_channels, axis=-1)
+
+    if data_format == "channels_first":
+        output = np.transpose(output, (0, 3, 1, 2))
+    if need_squeeze:
+        output = np.squeeze(output, axis=0)
+
+    return output
+
+
+def _compute_homography_matrix(start_points, end_points):
+    start_x1, start_y1 = start_points[:, 0, 0], start_points[:, 0, 1]
+    start_x2, start_y2 = start_points[:, 1, 0], start_points[:, 1, 1]
+    start_x3, start_y3 = start_points[:, 2, 0], start_points[:, 2, 1]
+    start_x4, start_y4 = start_points[:, 3, 0], start_points[:, 3, 1]
+
+    end_x1, end_y1 = end_points[:, 0, 0], end_points[:, 0, 1]
+    end_x2, end_y2 = end_points[:, 1, 0], end_points[:, 1, 1]
+    end_x3, end_y3 = end_points[:, 2, 0], end_points[:, 2, 1]
+    end_x4, end_y4 = end_points[:, 3, 0], end_points[:, 3, 1]
+
+    coefficient_matrix = np.stack(
+        [
+            np.stack(
+                [
+                    end_x1,
+                    end_y1,
+                    np.ones_like(end_x1),
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    -start_x1 * end_x1,
+                    -start_x1 * end_y1,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    np.zeros_like(end_x1),
+                    end_x1,
+                    end_y1,
+                    np.ones_like(end_x1),
+                    -start_y1 * end_x1,
+                    -start_y1 * end_y1,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    end_x2,
+                    end_y2,
+                    np.ones_like(end_x2),
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    -start_x2 * end_x2,
+                    -start_x2 * end_y2,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    np.zeros_like(end_x2),
+                    end_x2,
+                    end_y2,
+                    np.ones_like(end_x2),
+                    -start_y2 * end_x2,
+                    -start_y2 * end_y2,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    end_x3,
+                    end_y3,
+                    np.ones_like(end_x3),
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    -start_x3 * end_x3,
+                    -start_x3 * end_y3,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    np.zeros_like(end_x3),
+                    end_x3,
+                    end_y3,
+                    np.ones_like(end_x3),
+                    -start_y3 * end_x3,
+                    -start_y3 * end_y3,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    end_x4,
+                    end_y4,
+                    np.ones_like(end_x4),
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    -start_x4 * end_x4,
+                    -start_x4 * end_y4,
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    np.zeros_like(end_x4),
+                    end_x4,
+                    end_y4,
+                    np.ones_like(end_x4),
+                    -start_y4 * end_x4,
+                    -start_y4 * end_y4,
+                ],
+                axis=-1,
+            ),
+        ],
+        axis=1,
+    )
+
+    target_vector = np.stack(
+        [
+            start_x1,
+            start_y1,
+            start_x2,
+            start_y2,
+            start_x3,
+            start_y3,
+            start_x4,
+            start_y4,
+        ],
+        axis=-1,
+    )
+    target_vector = np.expand_dims(target_vector, axis=-1)
+
+    homography_matrix = np.linalg.solve(coefficient_matrix, target_vector)
+    homography_matrix = np.reshape(homography_matrix, [-1, 8])
+
+    return homography_matrix
 
 
 class ImageOpsCorrectnessTest(testing.TestCase):
@@ -1213,6 +1458,50 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )(image)
         self.assertAllClose(ref_cropped_image, cropped_image)
 
+    @parameterized.named_parameters(
+        named_product(
+            interpolation=["bilinear", "nearest"],
+        )
+    )
+    def test_perspective_transform(self, interpolation):
+        # Test channels_last
+        np.random.seed(42)
+        x = np.random.uniform(size=(50, 50, 3)).astype("float32")
+        start_points = np.random.uniform(size=(1, 4, 2)).astype("float32")
+        end_points = np.random.uniform(size=(1, 4, 2)).astype("float32")
+
+        out = kimage.perspective_transform(
+            x, start_points, end_points, interpolation=interpolation
+        )
+
+        ref_out = _perspective_transform_numpy(
+            x, start_points, end_points, interpolation=interpolation
+        )
+
+        self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
+        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+
+        # Test channels_first
+        backend.set_image_data_format("channels_first")
+        x = np.random.uniform(size=(3, 50, 50)).astype("float32")
+        start_points = np.random.uniform(size=(1, 4, 2)).astype("float32")
+        end_points = np.random.uniform(size=(1, 4, 2)).astype("float32")
+
+        out = kimage.perspective_transform(
+            x, start_points, end_points, interpolation=interpolation
+        )
+
+        ref_out = _perspective_transform_numpy(
+            x,
+            start_points,
+            end_points,
+            interpolation=interpolation,
+            data_format="channels_first",
+        )
+
+        self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
+        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+
 
 class ImageOpsBehaviorTests(testing.TestCase):
     def setUp(self):
@@ -1446,3 +1735,83 @@ class ImageOpsBehaviorTests(testing.TestCase):
             ValueError, "When the width of the images is unknown"
         ):
             kimage.crop_images(x, 2, 3, 4, 5)
+
+    def test_perspective_transform_invalid_images_rank(self):
+        # Test rank=2
+        invalid_image = np.random.uniform(size=(10, 10))
+        start_points = np.random.uniform(size=(6,))
+        end_points = np.random.uniform(size=(6,))
+        with self.assertRaisesRegex(
+            ValueError, "Invalid images rank: expected rank 3"
+        ):
+            kimage.perspective_transform(
+                invalid_image, start_points, end_points
+            )
+        with self.assertRaisesRegex(
+            ValueError, "Invalid images rank: expected rank 3"
+        ):
+            kimage.PerspectiveTransform()(
+                invalid_image, start_points, end_points
+            )
+
+        # Test rank=5
+        invalid_image = np.random.uniform(size=(2, 10, 10, 3, 1))
+        start_points = np.random.uniform(size=(6,))
+        end_points = np.random.uniform(size=(6,))
+        with self.assertRaisesRegex(
+            ValueError, "Invalid images rank: expected rank 3"
+        ):
+            kimage.perspective_transform(
+                invalid_image, start_points, end_points
+            )
+        with self.assertRaisesRegex(
+            ValueError, "Invalid images rank: expected rank 3"
+        ):
+            kimage.PerspectiveTransform()(
+                invalid_image, start_points, end_points
+            )
+
+        # Test rank=2, symbolic tensor
+        invalid_image = KerasTensor(shape=(10, 10))
+        start_points = KerasTensor(shape=(6,))
+        end_points = np.random.uniform(size=(6,))
+        with self.assertRaisesRegex(
+            ValueError, "Invalid images rank: expected rank 3"
+        ):
+            kimage.perspective_transform(
+                invalid_image, start_points, end_points
+            )
+
+    def test_perspective_transform_invalid_points_rank(self):
+        # Test rank=3
+        images = np.random.uniform(size=(10, 10, 3))
+        start_points = np.random.uniform(size=(2, 2, 4, 2))
+        end_points = np.random.uniform(size=(2, 2, 4, 2))
+        with self.assertRaisesRegex(
+            ValueError, "Invalid start_points shape: expected"
+        ):
+            kimage.perspective_transform(images, start_points, end_points)
+        with self.assertRaisesRegex(
+            ValueError, "Invalid start_points shape: expected"
+        ):
+            kimage.PerspectiveTransform()(images, start_points, end_points)
+
+        # Test rank=0
+        start_points = np.random.uniform(size=())
+        end_points = np.random.uniform(size=())
+        with self.assertRaisesRegex(
+            ValueError, "Invalid start_points shape: expected"
+        ):
+            kimage.perspective_transform(images, start_points, end_points)
+        with self.assertRaisesRegex(
+            ValueError, "Invalid start_points shape: expected"
+        ):
+            kimage.PerspectiveTransform()(images, start_points, end_points)
+
+        # Test rank=3, symbolic tensor
+        images = KerasTensor(shape=(10, 10, 3))
+        start_points = KerasTensor(shape=(2, 3, 2))
+        with self.assertRaisesRegex(
+            ValueError, "Invalid start_points shape: expected"
+        ):
+            kimage.perspective_transform(images, start_points, end_points)


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/20899

I have implemented the perspective_transform method using NumPy and TensorFlow. If this concept and implementation prove to be applicable, I can proceed with adding support for Torch and JAX as well.

here is my [gist](https://colab.research.google.com/drive/1GhIKYjaeaYP4-B-mWvh98rM3MK5b3lzc?usp=sharing)